### PR TITLE
Fix Clojure 1.9 exception

### DIFF
--- a/src/clojure/zensols/actioncli/resource.clj
+++ b/src/clojure/zensols/actioncli/resource.clj
@@ -104,7 +104,7 @@
 
   * **:create** if `:file` then create the director(ies) on the
   file system, otherwise if `:dir` then create all parent directories"
-  ([key child-file & {:keys [create] :or {:create nil}}]
+  ([key child-file & {:keys [create] :or {create nil}}]
    (let [parent (resolve-function key false)
          path (resolve-resource (cond (instance? File parent) :file
                                       (function? parent) :function


### PR DESCRIPTION
Use symbol `create` instead of keyword `:create` to support Clojure 1.9 . Fixes #1 

__Breaks on 1.9__

`(defn resource-path ([key child-file & {:keys create :or {:create nil}}] :foo) ([key] :bar))`

__Works on both  1.8 and 1.9__

`(defn resource-path ([key child-file & {:keys create :or {create nil}}] :foo) ([key] :bar))`

I didn't know this was valid in 1.8.